### PR TITLE
Ort compatibility

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,9 +1,17 @@
 import launch
 
 
+if not launch.is_installed('onnxruntime') and not launch.is_installed('onnxruntime-gpu'):
+    # with older versions of a webui you need to check for both cpu and gpu onnxruntime otherwise it will fail to detect it properly
+    import torch.cuda as cuda
+    # torch imported here only when necessary, importing it at the beginning would immediately slow down load time
+    if cuda.is_available():
+        launch.run_pip('install onnxruntime-gpu')
+    else:
+        launch.run_pip('install onnxruntime')
+
 pip_dependencies = [
     'rembg==2.0.38 --no-deps',
-    'onnxruntime',
     'pymatting',
     'pooch'
 ]

--- a/lib_inpaint_background/mask_processing.py
+++ b/lib_inpaint_background/mask_processing.py
@@ -23,7 +23,7 @@ def compute_mask(
 
     if BackgroundGlobals.rembg_model_string != model_str:
         BackgroundGlobals.rembg_model_string = model_str
-        BackgroundGlobals.rembg_session = rembg.new_session(model_str)
+        BackgroundGlobals.rembg_session = rembg.new_session(model_str, providers=['CPUExecutionProvider'])
 
     mask = rembg.remove(
         base_img,


### PR DESCRIPTION
onnxruntime have onnxruntime and onnxruntime-gpu
in your case it doesn't matter if you're using CPU or GPU because the model is relatively lightweight
> and I think CPU even works better because you don't have to send data across to the GPU so it might even be faster

but `onnxruntime` is used by lots of extensions and in some cases they do require onnxruntime-gpu
the issue is that you can only install one onnxruntime and not both at the same time
otherwise irrc strange issues would occur

so currently I believe the best practice is to install the GPU version when GPU is available install even when you are not going to use the GPU provider

I have performed this procedure on multiple extensions that use onnxruntime

---

if you are bored like me you can add an option to let the user choose which provider to use
https://github.com/w-e-w/sd-webui-nudenet-nsfw-censor/blob/8162bc8a925f5a6884323a141331148a677396de/scripts/nudenet_nsfw_censor_scripts/pil_nude_detector.py#L65
https://github.com/w-e-w/sd-webui-nudenet-nsfw-censor/blob/8162bc8a925f5a6884323a141331148a677396de/scripts/nudenet_nsfw_censor_scripts/settings.py#L25
